### PR TITLE
Reset device discovery cache to allow multiple devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "form-data": "^4.0.0",
     "luxon": "^2.0.2",
     "node-telegram-bot-api": "^0.66.0",
+    "quickchart-js": "^3.1.3",
     "table": "^6.7.1",
+    "tuyapi": "^7.7.1",
     "uuid": "^10.0.0",
-    "yargs": "^17.1.1",
-    "quickchart-js": "^3.1.3"
+    "yargs": "^17.1.1"
   },
   "devDependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",

--- a/src/lib/deviceManager.ts
+++ b/src/lib/deviceManager.ts
@@ -11,6 +11,13 @@ export class DeviceManager {
 
   async discoverLocalDevices(): Promise<any[]> {
     try {
+      // Reset seen devices before each discovery to allow multiple
+      // sequential discovery runs. Previously, repeated calls would
+      // return no devices because broadcasts from earlier runs were
+      // cached in the set, preventing processing of the same devices
+      // again.
+      this.devicesSeen.clear();
+
       this.log.info('Starting LAN discovery...');
       const localDevicesPort2 = await this.discoverDevices(6667);
       const localDevicesPort1 = await this.discoverDevices(6666);

--- a/src/lib/smartPlugService.ts
+++ b/src/lib/smartPlugService.ts
@@ -64,6 +64,12 @@ export class SmartPlugService {
 
   async discoverLocalDevices(): Promise<any[]> {
     try {
+      // Reset seen devices for each discovery run so multiple calls can
+      // discover the same devices independently. Without clearing this set,
+      // subsequent discovery attempts would return no results because the
+      // broadcast messages were cached from previous runs.
+      this.devicesSeen.clear();
+
       this.log.info('Starting LAN discovery...');
       const localDevicesPort2 = await this.discoverDevices(6667);
       const localDevicesPort1 = await this.discoverDevices(6666);

--- a/test/lib/deviceManager.multiple.test.ts
+++ b/test/lib/deviceManager.multiple.test.ts
@@ -1,0 +1,31 @@
+import { DeviceManager } from '../../src/lib/deviceManager';
+import { Logger } from 'homebridge';
+
+describe('DeviceManager multiple discovery', () => {
+  const log = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as Logger;
+
+  it('discovers devices on subsequent calls', async () => {
+    const manager = new DeviceManager(null as any, log);
+
+    // Mock the private discoverDevices method to avoid network operations
+    (manager as any).discoverDevices = async function(_port: number) {
+      const key = 'dummy';
+      if ((this as any).devicesSeen.has(key)) {
+        return [];
+      }
+      (this as any).devicesSeen.add(key);
+      return [{ deviceId: 'dev1', ip: '0.0.0.0', version: '3.3' }];
+    };
+
+    const first = await manager.discoverLocalDevices();
+    const second = await manager.discoverLocalDevices();
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(second.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- clear cached broadcast messages before each device discovery so multiple calls see all devices
- ensure device manager behaves the same way
- add unit test covering repeated discovery

## Testing
- `npm run lint`
- `npm test` *(fails: test suites contain no tests)*
- `npx jest test/lib/deviceManager.multiple.test.ts`