### PR TITLE
Add optional full power log export for laundry cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [How Does the Tool Ensure Accuracy?](#%EF%B8%8F-how-does-the-tool-ensure-accuracy)
 - [How LAN Interaction Works](#-how-lan-interaction-works-)
 - [kWh Calculation: Why It Works](#-kwh-calculation-why-it-works-)
+- [Power Log Export](#-power-log-export)
 - [Telegram Setup](#-telegram-setup)
 - [Pushed.co Setup](#-pushedco-setup)
 - [ntfy Setup](#-ntfy-setup)
@@ -251,11 +252,62 @@ The plugin calculates your appliance’s energy consumption in **kilowatt-hours 
 
 ### 🌟 **Why It Matters**
 
-- **Monitor Costs**: Know your appliance’s electricity usage.  
-- **Spot Inefficiencies**: Identify unusual consumption.  
+- **Monitor Costs**: Know your appliance’s electricity usage.
+- **Spot Inefficiencies**: Identify unusual consumption.
 - **Stay Sustainable**: Reduce and optimize energy use. 🌍💡
 
---- 
+---
+
+## 🗒️ Power Log Export
+
+Enable detailed measurement logging by setting `exportPowerLog` to `true`
+for a device in your Homebridge config. When enabled, every polled power
+value is recorded and, after each completed cycle, written to
+`logs/<deviceId>-<ISO_TIMESTAMP>.json`. The exported file contains
+metadata about the cycle and a `powerLog` array with the collected
+measurements.
+
+```json
+{
+  "laundryDevices": [
+    {
+      "deviceId": "your-device-id",
+      "localKey": "your-local-key",
+      "powerValueId": "19",
+      "exportPowerLog": true
+    }
+  ]
+}
+```
+
+### Example
+
+```json
+{
+  "startTime": "2024-05-05T12:00:00.000Z",
+  "endTime": "2024-05-05T12:30:00.000Z",
+  "durationSec": 1800,
+  "minPower": 5.2,
+  "maxPower": 120.4,
+  "avgPower": 60.1,
+  "totalKWh": 0.34,
+  "powerLog": [
+    {
+      "timestamp": "2024-05-05T12:00:01.000Z",
+      "watt": 10.5,
+      "deltaWs": 10.5,
+      "totalKWh": 0.000003,
+      "isActive": true,
+      "interval": 1000,
+      "rawDps": {"19": 105},
+      "voltage": 2300,
+      "current": 50
+    }
+  ]
+}
+```
+
+---
 
 ## 📡 Push Notifications Setup 🚀
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -205,6 +205,13 @@
               "required": false,
               "description": "Creates dummy switch that will indicate the current device status, useful for extra automation",
               "default": false
+            },
+            "exportPowerLog": {
+              "title": "Export Power Log",
+              "type": "boolean",
+              "required": false,
+              "description": "Write detailed power measurements for each cycle to logs/<deviceId>-<timestamp>.json",
+              "default": false
             }
           }
         }

--- a/example/config.json
+++ b/example/config.json
@@ -18,7 +18,8 @@
           "endValue": 300,
           "endDuration": 30,
           "startMessage": "⏳ Washing machine started the cycle!",
-          "endMessage": "✅ Washing machine finished!"
+          "endMessage": "✅ Washing machine finished!",
+          "exportPowerLog": true
         }
       ]
     }

--- a/src/interfaces/notifyConfig.ts
+++ b/src/interfaces/notifyConfig.ts
@@ -48,4 +48,5 @@ export interface LaundryDeviceConfig {
     endMessage?: string;               // Message sent at the end of the cycle
     exposeStateSwitch?: boolean;       // Option to expose a switch for automation
     protocolVersion?: string;          // Optional protocol version field
+    exportPowerLog?: boolean;          // Whether to export detailed power logs
 }

--- a/src/lib/laundryDeviceTracker.ts
+++ b/src/lib/laundryDeviceTracker.ts
@@ -1,8 +1,29 @@
 import { LaundryDeviceConfig } from '../interfaces/notifyConfig';
 import { API, Logger, PlatformAccessory } from 'homebridge';
 import { DateTime } from 'luxon';
+import fs from 'fs';
+import path from 'path';
 import { MessageGateway } from './messageGateway';
 import { SmartPlugService } from './smartPlugService';
+
+interface PowerMeasurement {
+  watt: number | null;
+  voltage?: number;
+  current?: number;
+  rawDps: any;
+}
+
+interface PowerLogEntry {
+  timestamp: string;
+  watt: number;
+  deltaWs: number;
+  totalKWh: number;
+  isActive: boolean;
+  interval: number;
+  rawDps: any;
+  voltage?: number;
+  current?: number;
+}
 
 export class LaundryDeviceTracker {
   private startDetected?: boolean;
@@ -14,6 +35,13 @@ export class LaundryDeviceTracker {
   private lastMeasurementTime: DateTime = DateTime.now(); // Time of the last measurement
   private lastDpsStatus: any = null; // Cached last DPS status
   private currentInterval = 5000; // Dynamic update interval in milliseconds
+  private powerLog: PowerLogEntry[] = [];
+  private startTime?: DateTime;
+  private endTime?: DateTime;
+  private minPower = Number.POSITIVE_INFINITY;
+  private maxPower = 0;
+  private totalPower = 0;
+  private sampleCount = 0;
   public accessory?: PlatformAccessory;
 
   constructor(
@@ -61,18 +89,18 @@ export class LaundryDeviceTracker {
     setInterval(async () => {
       try {
         const deviceName = this.config.name || this.config.deviceId;
-        const powerValue = await this.getPowerValue(selectedDevice);
+        const powerData = await this.getPowerValue(selectedDevice);
 
-        if (typeof powerValue !== 'number') {
-          this.log.error(`Received invalid power value: ${powerValue} (expected a number).`);
+        if (typeof powerData.watt !== 'number') {
+          this.log.error(`Received invalid power value: ${powerData.watt} (expected a number).`);
           return;
         }
 
-        this.log.debug(`Current power for ${deviceName}: ${powerValue}W`);
-        this.incomingData(powerValue);
+        this.log.debug(`Current power for ${deviceName}: ${powerData.watt}W`);
+        this.incomingData(powerData.watt);
 
         // Run the helper method to check start and stop conditions
-        await this.checkStartStopConditions(deviceName, powerValue);
+        await this.checkStartStopConditions(deviceName, powerData);
 
       } catch (error) {
         this.log.error(`Error during start/stop detection: ${error.message}`);
@@ -81,19 +109,27 @@ export class LaundryDeviceTracker {
   }
 
   // Helper method to get power value with caching
-  private async getPowerValue(selectedDevice: any): Promise<number | null> {
+  private async getPowerValue(selectedDevice: any): Promise<PowerMeasurement> {
     const dpsStatus = await this.smartPlugService.getLocalDPS(selectedDevice, this.log);
 
     if (JSON.stringify(dpsStatus) === JSON.stringify(this.lastDpsStatus)) {
       this.log.debug(`No change in device status for ${selectedDevice.deviceId}, skipping further checks.`);
-      return this.lastDpsStatus?.dps[this.config.powerValueId];
+      const cached = this.lastDpsStatus?.dps[this.config.powerValueId];
+      return { watt: cached !== undefined ? cached : null, rawDps: this.lastDpsStatus };
     }
 
     this.lastDpsStatus = dpsStatus;
 
     // Explizit prüfen, ob powerValue definiert ist, um 0 als gültigen Wert zu akzeptieren
     const powerValue = dpsStatus?.dps[this.config.powerValueId];
-    return powerValue !== undefined ? powerValue : null;
+    const voltage = dpsStatus?.dps['20'];
+    const current = dpsStatus?.dps['18'];
+    return {
+      watt: powerValue !== undefined ? powerValue : null,
+      voltage,
+      current,
+      rawDps: dpsStatus,
+    };
   }
 
   // Method to dynamically adjust the interval based on activity
@@ -103,7 +139,9 @@ export class LaundryDeviceTracker {
   }
 
   // Helper method to check start and stop conditions
-  private async checkStartStopConditions(deviceName: string, powerValue: number) {
+  private async checkStartStopConditions(deviceName: string, powerData: PowerMeasurement) {
+    const powerValue = powerData.watt as number;
+
     // Check whether the machine started
     if (!this.isActive && this.startDetected && this.startDetectedTime) {
       const secondsDiff = DateTime.now().diff(this.startDetectedTime, 'seconds').seconds;
@@ -120,19 +158,49 @@ export class LaundryDeviceTracker {
         this.startDetected = false; // Reset start detection
         this.startDetectedTime = undefined;
         this.adjustInterval(true); // Switch to a more frequent interval
+        this.startTime = DateTime.now();
+        this.powerLog = [];
+        this.lastMeasurementTime = DateTime.now();
+        this.minPower = Number.POSITIVE_INFINITY;
+        this.maxPower = 0;
+        this.totalPower = 0;
+        this.sampleCount = 0;
       }
     }
 
-    // Accumulate energy consumption if the machine is running
+    const now = DateTime.now();
+    const timeDiff = now.diff(this.lastMeasurementTime, 'seconds').seconds;
+    this.lastMeasurementTime = now;
+
+    const powerW = powerValue / 10;
+    const energyConsumed = powerW * timeDiff; // in watt-seconds (W-s)
+
     if (this.isActive) {
-      const now = DateTime.now();
-      const timeDiff = now.diff(this.lastMeasurementTime, 'seconds').seconds;
-      this.lastMeasurementTime = now;
-
-      const energyConsumed = (powerValue / 10) * timeDiff; // in watt-seconds (W-s)
       this.cumulativeConsumption += energyConsumed;
+      this.minPower = Math.min(this.minPower, powerW);
+      this.maxPower = Math.max(this.maxPower, powerW);
+      this.totalPower += powerW;
+      this.sampleCount++;
+    }
 
-      this.log.debug(`Added ${energyConsumed} W·s. Total cumulativeConsumption: ${this.cumulativeConsumption} W·s, ${(this.cumulativeConsumption / 3600000).toFixed(4)} kWh`);
+    const totalKWh = this.cumulativeConsumption / 3600000;
+
+    if (this.config.exportPowerLog && (this.isActive || this.startDetected || this.endDetected)) {
+      this.powerLog.push({
+        timestamp: now.toISO(),
+        watt: powerW,
+        deltaWs: energyConsumed,
+        totalKWh,
+        isActive: !!this.isActive,
+        interval: this.currentInterval,
+        rawDps: powerData.rawDps,
+        voltage: powerData.voltage,
+        current: powerData.current,
+      });
+    }
+
+    if (this.isActive) {
+      this.log.debug(`Added ${energyConsumed} W·s. Total cumulativeConsumption: ${this.cumulativeConsumption} W·s, ${totalKWh.toFixed(4)} kWh`);
     }
 
     // Check whether the machine has stopped
@@ -145,10 +213,27 @@ export class LaundryDeviceTracker {
         const endMessage = `${this.config.endMessage || ''} Total consumption: ${kWhConsumed.toFixed(2)} kWh.`;
         this.messageGateway.send(endMessage);
         this.updateAccessorySwitchState(false);
+
+        this.endTime = DateTime.now();
+        const durationSec = this.startTime ? this.endTime.diff(this.startTime, 'seconds').seconds : 0;
+        const avgPower = this.sampleCount > 0 ? this.totalPower / this.sampleCount : 0;
+        if (this.config.exportPowerLog) {
+          await this.exportPowerLog({
+            startTime: this.startTime?.toISO(),
+            endTime: this.endTime.toISO(),
+            durationSec,
+            minPower: this.minPower === Number.POSITIVE_INFINITY ? 0 : this.minPower,
+            maxPower: this.maxPower,
+            avgPower,
+            totalKWh: kWhConsumed,
+          });
+        }
+
         this.cumulativeConsumption = 0; // Reset for the next cycle
         this.endDetected = false; // Reset end detection
         this.endDetectedTime = undefined;
         this.adjustInterval(false); // Switch to a less frequent interval
+        this.powerLog = [];
       }
     }
   }
@@ -185,6 +270,30 @@ export class LaundryDeviceTracker {
       const service = this.accessory.getService(this.api.hap.Service.Switch);
       service?.setCharacteristic(this.api.hap.Characteristic.On, isOn);
       this.log.debug(`Updated accessory switch state for ${this.config.name}: ${isOn ? 'On' : 'Off'}`);
+    }
+  }
+
+  private async exportPowerLog(stats: {
+    startTime?: string;
+    endTime: string;
+    durationSec: number;
+    minPower: number;
+    maxPower: number;
+    avgPower: number;
+    totalKWh: number;
+  }) {
+    try {
+      const deviceId = this.config.deviceId;
+      const timestamp = (stats.endTime || DateTime.now().toISO()).replace(/:/g, '-');
+      const dir = path.resolve('logs');
+      await fs.promises.mkdir(dir, { recursive: true });
+      const filePath = path.join(dir, `${deviceId}-${timestamp}.json`);
+      const data = JSON.stringify({ ...stats, powerLog: this.powerLog }, null, 2);
+      await fs.promises.writeFile(filePath, data);
+      this.log.info(`Exported power log to ${filePath}`);
+      this.powerLog = [];
+    } catch (error) {
+      this.log.error(`Failed to export power log: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `exportPowerLog` device option to write detailed cycle measurements to JSON
- capture every polled power sample with watt-second deltas, cumulative kWh, and raw DPS data
- document power log configuration and provide example config